### PR TITLE
Graph collection was fixed for case when it includes UIOP

### DIFF
--- a/src/asdf.lisp
+++ b/src/asdf.lisp
@@ -14,7 +14,12 @@
                  :attributes (list :label (format nil "~a~:[~*~; (~a)~]"
                                                   (asdf:component-name object)
                                                   *license*
-                                                  (asdf:system-license object))
+                                                  ;; For some reason asdf:system-license
+                                                  ;; fails on some systems like :UIOP
+                                                  ;; because asdf:primary-system-name returns NIL
+                                                  ;; for them.
+                                                  (when (asdf:primary-system-name object)
+                                                    (asdf:system-license object)))
                                    :shape :octagon
                                    :style :filled
                                    :fillcolor "#eeeeff")))


### PR DESCRIPTION
Previosly, it resulted in "NIL is not a valid system name" error:

```
NIL is not a valid system name
   [Condition of type ASDF/SESSION:FORMATTED-SYSTEM-DEFINITION-ERROR]

Restarts:
 0: [RETRY] Retry SLY mREPL evaluation request.
 1: [*ABORT] Return to SLY's top level.
 2: [ABORT] abort thread (#<THREAD "sly-channel-1-mrepl-remote-1" RUNNING {100394D853}>)

Backtrace:
 0: (ASDF/SESSION:SYSDEF-ERROR "~@<NIL is not a valid system name~@:>")
 1: (ASDF/SYSTEM::SYSTEM-VIRTUAL-SLOT-VALUE #<ASDF/SYSTEM:SYSTEM "uiop"> ASDF/COMPONENT:LICENCE)
 2: ((:METHOD CL-DOT:GRAPH-OBJECT-NODE ((EQL (QUOTE ASDF-VIZ:DEPENDSON)) ASDF/COMPONENT:COMPONENT)) #<unused argument> #<ASDF/SYSTEM:SYSTEM "uiop">) [fast-method]
 3: ((LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) #<ASDF/SYSTEM:SYSTEM "uiop">)
 4: (SB-KERNEL:%MAP-FOR-EFFECT-ARITY-1 #<CLOSURE (LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) {1004EF158B}> (#<ASDF/SYSTEM:SYSTEM "uiop"> #<ASDF/SYSTEM:SYSTEM "alexandria"> #<ASDF/SYSTEM:SYS..
 5: ((LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) #<ASDF/SYSTEM:SYSTEM "cffi">)
 6: (SB-KERNEL:%MAP-FOR-EFFECT-ARITY-1 #<CLOSURE (LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) {1004EF158B}> (#<ASDF/SYSTEM:SYSTEM "alexandria"> #<ASDF/SYSTEM:SYSTEM "cffi"> #<ASDF/SYSTEM:SYS..
 7: ((LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) #<ASDF/SYSTEM:SYSTEM "ppath">)
 8: (SB-KERNEL:%MAP-FOR-EFFECT-ARITY-1 #<CLOSURE (LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) {1004EF158B}> (#<ASDF/SYSTEM:SYSTEM "cl-org-mode"> #<ASDF/SYSTEM:SYSTEM "cl-bootstrap"> #<ASDF/S..
 9: ((LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) #<ASDF/SYSTEM:SYSTEM "poftheday">)
10: (SB-KERNEL:%MAP-FOR-EFFECT-ARITY-1 #<CLOSURE (LABELS CL-DOT::HANDLE-OBJECT :IN CL-DOT::CONSTRUCT-GRAPH) {1004EF158B}> (#<ASDF/SYSTEM:SYSTEM "poftheday">))
11: (CL-DOT::CONSTRUCT-GRAPH ASDF-VIZ:DEPENDSON (#<ASDF/SYSTEM:SYSTEM "poftheday">))
12: ((:METHOD CL-DOT:GENERATE-GRAPH-FROM-ROOTS (T T)) ASDF-VIZ:DEPENDSON (#<ASDF/SYSTEM:SYSTEM "poftheday">) (:RANKDIR "LR")) [fast-method]
13: (ASDF-VIZ:VISUALIZE-ASDF-HIERARCHY "poftheday" (#<ASDF/SYSTEM:SYSTEM "poftheday">) ASDF-VIZ:DEPENDSON)
```

To reproduce this issue, do:

```
$ ros install 40ants/lisp-project-of-the-day
$ ros install asdf-viz
$ asdf-viz test.png poftheday
Making core for Roswell...
Unhandled ASDF/SESSION:FORMATTED-SYSTEM-DEFINITION-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                                      {1000530083}>:
  NIL is not a valid system name

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1000530083}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<ASDF/SESSION:FORMATTED-SYSTEM-DEFINITION-ERROR {10020CF593}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<ASDF/SESSION:FORMATTED-SYSTEM-DEFINITION-ERROR {10020CF593}>)
```